### PR TITLE
Fix #2 and #3 By Using a try / catch Instead of .catch()

### DIFF
--- a/binary/tsc-esm.js
+++ b/binary/tsc-esm.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { build } from "../library/index.js"
-build().catch(error => {
+try {
+	build()
+} catch (error) {
 	console.error(error)
 	process.exit(1)
-})
+}


### PR DESCRIPTION
#2 and #3 are receiving `typeerrors` from the `build()` function chaining a `catch()` function on the end of it. Unfortunately, `build()` is not an async function, nor does it return a promise (or anything at all), so `catch` isn't an available method to look for errors. I wrapped this in a `try / catch` to fix any errors that may be surfaced, keeping the original behavior while fixing the issue