### PR TITLE
Add support for custom tsconfig.json files

### DIFF
--- a/library/index.js
+++ b/library/index.js
@@ -31,14 +31,15 @@ export function patch(aliases) {
 /**
  * @return the output directories of typescript compiler
  */
-function getOutputDirectories() {
-	if (existsSync("tsconfig.json")) {
+function getOutputDirectories(tsconfig) {
+	if (existsSync(tsconfig)) {
 		try {
-			const { compilerOptions } = parse(readFileSync("tsconfig.json", "utf8"))
+			const { compilerOptions, extends: parentConfigFile } = parse(readFileSync(tsconfig, "utf8"))
 			if (compilerOptions.outDir) return globDirectory(compilerOptions.outDir)
 			if (compilerOptions.outFile) return globDirectory(path.join(compilerOptions.outFile, '..'))
+			if (parentConfigFile) return getOutputDirectories(path.resolve(tsconfig, parentConfigFile))
 		} catch (error) {
-			throw new SyntaxError(`Could not parse tsconfig.json file. ${error}`)
+			throw new SyntaxError(`Could not parse tsconfig.json file at ${tsconfig}. ${error}`)
 		}
 	}
 	return ["."]

--- a/library/index.js
+++ b/library/index.js
@@ -23,7 +23,8 @@ export function compile() {
 }
 
 export function patch(aliases) {
-	const directories = getOutputDirectories()
+	const tsconfig = getConfigFile(process.argv.slice(2))
+	const directories = getOutputDirectories(tsconfig)
 	patchJsImports(directories, aliases)
 }
 
@@ -41,4 +42,16 @@ function getOutputDirectories() {
 		}
 	}
 	return ["."]
+}
+
+function getConfigFile(argv) {
+	const projectIndex = Math.max(argv.indexOf('-p'), argv.indexOf('--project'))
+	const projectOrTsConfig = argv[projectIndex + 1]
+	if (!projectOrTsConfig) {
+		return 'tsconfig.json'
+	}
+	if (projectOrTsConfig.endsWith('.json')) {
+		return projectOrTsConfig
+	}
+	return path.join(projectOrTsConfig, 'tsconfig.json')
 }

--- a/library/index.js
+++ b/library/index.js
@@ -19,7 +19,7 @@ export function build(aliases) {
 }
 
 export function compile() {
-	spawnSync("node_modules/.bin/tsc", { stdio: 'inherit' })
+	spawnSync("node_modules/.bin/tsc", process.argv.slice(2), { stdio: 'inherit' })
 }
 
 export function patch(aliases) {


### PR DESCRIPTION
Thanks for this tool! 🥳 We're currently starting to use ESM with Next.JS 12 and the missing file extensions almost made us drop that effort.

We're using a `tsconfig.json` that has a non-default name, this PR enables it. It also resolves the `extend` chain in case the outDir/outFile is defined in a parent config.